### PR TITLE
Do not manipulate data urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = postcss.plugin('prefix', (options) => {
   }
 
   this.formatUrl = (path, includePrefix) => {
+    const isDataUri = /^["']?data:/i.test(path);
     includePrefix = typeof includePrefix !== 'undefined' ? includePrefix : true;
     const sanitizedPath = path.replace(/['"]/g, '');
 
@@ -43,8 +44,9 @@ module.exports = postcss.plugin('prefix', (options) => {
     }
 
     const prefix = includePrefix ? this.getPrefix(sanitizedPath) : '';
+    const formatted = isDataUri ? path : url.resolve(prefix, sanitizedPath);
 
-    return `url(${url.resolve(prefix, sanitizedPath)})`;
+    return `url(${formatted})`;
   };
 
   return postcss().use(functions({

--- a/test/fixtures/url.css
+++ b/test/fixtures/url.css
@@ -5,3 +5,7 @@ body {
 p {
   background: url('/test2.png');
 }
+
+span {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="#fff" viewBox="0 0 8 8"><path d="M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z"/></svg>');
+}

--- a/test/fixtures/url.out.css
+++ b/test/fixtures/url.out.css
@@ -5,3 +5,7 @@ body {
 p {
   background: url(https://img2.example.com/test2.png);
 }
+
+span {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="#fff" viewBox="0 0 8 8"><path d="M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z"/></svg>');
+}


### PR DESCRIPTION
fixes #1 

Data urls should not be sanitized or prefixed. This change simply leaves `data:` urls as-is.